### PR TITLE
Corrixir python.py

### DIFF
--- a/python.tex
+++ b/python.tex
@@ -174,7 +174,6 @@ Type "help", "copyright", "credits" or "license" for more information.
   \item Enteiros (int)
   \item Numeros en punto flotante (float)
   \item Números longos (long)
-  \item Números en base octal e hexadecimal
   \item Números complexos (complex)
   \item Caracteres (char)
   \item Cadeas de caracteres (string)
@@ -185,8 +184,8 @@ Type "help", "copyright", "credits" or "license" for more information.
 \begin{frame}
   \frametitle{Operadores lóxicos}
   \begin{itemize}
-  \item and, \&
-  \item or, $|$
+  \item and
+  \item or
   \item not
   \item is, is not
   \item in, not in


### PR DESCRIPTION
- `&` e `|` son operadores *binarios* , non lóxicos (operan a nivel de bit sobre enteiros, non a nivel de verdade sobre booleanos).
- A representación en octal ou hexadecimal non son parte do tipo de dato, é simplemente unha representación diferente dun valor determinado do mesmo tipo de dato. As funcións `hex()` e `bin()` por exemplo son funcións que devolven *strings*, porque Python non pode devolver un número noutra base, un número é un número (internamente é binario).

Outra representación dos valores numéricos pode ser [decimal][1], que é unha representación numérica en punto fixo (en lugar de punto flotante). Digo, por contrastar, non suxiro que se mencione nesta charla :-)

  [1]: https://docs.python.org/2/library/decimal.html